### PR TITLE
Remove initial-scale=1.0 from viewport meta tag in default template

### DIFF
--- a/frontend/views/templates/default.hbs
+++ b/frontend/views/templates/default.hbs
@@ -5,7 +5,7 @@
 <!--[if gt IE 9]><!--> <html class="no-js" lang="{{lang}}"> <!--<![endif]-->
 <head>
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="viewport" content="width=device-width" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<title>{{docTitle}}</title>
 	<style>


### PR DESCRIPTION
See https://github.com/h5bp/html5-boilerplate/issues/824
